### PR TITLE
fix: fix a typo

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -219,13 +219,13 @@ global.afrim = Object({
         textFieldElement.selectionEnd,
       );
 
-      tooltip.style.top =
+      tooltipElement.style.top =
         125 +
         textFieldElement.offsetTop -
         textFieldElement.scrollTop +
         caret.top +
         "px";
-      tooltip.style.left =
+      tooltipElement.style.left =
         50 +
         textFieldElement.offsetLeft -
         textFieldElement.scrollLeft +


### PR DESCRIPTION
### Description
Var name `tooltip` was not declared.

### Change
Replaced `tooltip` by the correct var name `tooltipElement`.

### Impact
Not a bug.
Because, looks like we can direct access an HTML element using his ID as variable name.