### PR TITLE
chore: update github links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
   <h1><code>afrim-web</code></h1>
 
-<strong>A <code>web platform</code> for the afrim input method engine powered by <a href="https://github.com/pythonbrad/afrim-js">afrim-js</a>.</strong>
+<strong>A <code>web platform</code> for the afrim input method engine powered by <a href="https://github.com/fodydev/afrim-js">afrim-js</a>.</strong>
 
   <p>
-    <a href="https://github.com/pythonbrad/afrim-web/actions/workflows/ci.yml"><img alt="Build Status" src="https://github.com/pythonbrad/afrim-web/actions/workflows/ci.yml/badge.svg?branch=main"/></a>&nbsp;
-    <a href="https://github.com/pythonbrad/afrim-web/actions/workflows/deploy.yml"><img alt="Deploy Status" src="https://github.com/pythonbrad/afrim-web/actions/workflows/deploy.yml/badge.svg?branch=main"/></a>
+    <a href="https://github.com/fodydev/afrim-web/actions/workflows/ci.yml"><img alt="Build Status" src="https://github.com/fodydev/afrim-web/actions/workflows/ci.yml/badge.svg?branch=main"/></a>&nbsp;
+    <a href="https://github.com/fodydev/afrim-web/actions/workflows/deploy.yml"><img alt="Deploy Status" src="https://github.com/fodydev/afrim-web/actions/workflows/deploy.yml/badge.svg?branch=main"/></a>
   </p>
 
-<img alt="Demo" src="https://github.com/pythonbrad/afrim-web/assets/45305909/d0cdf903-c2bc-4a1b-8bf7-d99d460c1019"/>
+<img alt="Demo" src="https://github.com/fodydev/afrim-web/assets/45305909/d0cdf903-c2bc-4a1b-8bf7-d99d460c1019"/>
 
 <sub>Built by <a href="https://github.com/pythonbrad">@pythonbrad</a></sub>
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "bugs": {
     "url": "https://fodydev.github.io/afrim-web"
   },
-  "homepage": "https://github.com/pythonbrad/afrim-web#readme",
+  "homepage": "https://github.com/fodydev/afrim-web#readme",
   "devDependencies": {
     "prettier": "3.2.5"
   }

--- a/packages/afrim-input/README.md
+++ b/packages/afrim-input/README.md
@@ -16,7 +16,7 @@ We also offer a lite version of this library for those who need a more lightweig
 
 You can find it here [npm/afrim-input-lite](https://www.npmjs.com/package/afrim-input-lite).
 
-**Note:** This version is based on afrim-lite. Confer [github/pythonbrad/afrim-lite](https://github.com/pythonbrad/afrim-js?tab=readme-ov-file#lite-version)
+**Note:** This version is based on afrim-lite. Confer [github/fodydev/afrim-lite](https://github.com/fodydev/afrim-js?tab=readme-ov-file#lite-version)
 
 ## 🚀 Usage
 
@@ -29,7 +29,7 @@ new Afrim({
   tooltipElementID: "tooltip",
   tooltipInputElementID: "tooltip-input",
   tooltipPredicatesElementID: "tooltip-predicates",
-  configUrl: `https://raw.githubusercontent.com/pythonbrad/afrim-data/4b177197bb37c9742cd90627b1ad543c32ec791b/gez/gez.toml`,
+  configUrl: `https://raw.githubusercontent.com/fodydev/afrim-data/4b177197bb37c9742cd90627b1ad543c32ec791b/gez/gez.toml`,
 });
 ```
 

--- a/packages/afrim-input/package.json
+++ b/packages/afrim-input/package.json
@@ -21,9 +21,9 @@
   "author": "Brady Fomegne <brady.fomegne@outlook.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/pythonbrad/afrim-web/issues"
+    "url": "https://github.com/fodydev/afrim-web/issues"
   },
-  "homepage": "https://github.com/pythonbrad/afrim-web#readme",
+  "homepage": "https://github.com/fodydev/afrim-web#readme",
   "dependencies": {
     "afrim-js": "^0.4.0",
     "ky": "^1.2.4",

--- a/packages/afrim-input/src/index.ts
+++ b/packages/afrim-input/src/index.ts
@@ -60,7 +60,7 @@ export default class AfrimInput {
       tooltipAdjustLeft: 0,
       tooltipAdjustTop: 0,
       configUrl:
-        "https://raw.githubusercontent.com/pythonbrad/afrim-data/4b177197bb37c9742cd90627b1ad543c32ec791b/gez/gez.toml",
+        "https://raw.githubusercontent.com/fodydev/afrim-data/4b177197bb37c9742cd90627b1ad543c32ec791b/gez/gez.toml",
     };
 
     // merge the options passed in with our default options

--- a/packages/afrim-playground/src/index.html
+++ b/packages/afrim-playground/src/index.html
@@ -48,7 +48,7 @@
               <span class="navbar-item">
                 <a
                   class="button is-inverted"
-                  href="https://github.com/pythonbrad/afrim-web"
+                  href="https://github.com/fodydev/afrim-web"
                   target="_blank"
                 >
                   <span class="icon">
@@ -144,7 +144,7 @@
             <p>
               <a
                 class="icon"
-                href="https://github.com/pythonbrad/afrim-web"
+                href="https://github.com/fodydev/afrim-web"
                 target="_blank"
               >
                 <i class="fab fa-github"></i>
@@ -164,7 +164,7 @@
                 >Brady Fomegne</a
               >. <br />
               Based on
-              <a href="https://github.com/pythonbrad/afrim-js" target="_blank"
+              <a href="https://github.com/fodydev/afrim-js" target="_blank"
                 >AfrimJS</a
               >. <br />
               The source code is licensed


### PR DESCRIPTION
With the migration of the project repos to the FodyDev org, the github url have changed.