### PR TITLE
fix(afrim-input): release the textfield on init fail

### DIFF
--- a/packages/afrim-input/src/index.ts
+++ b/packages/afrim-input/src/index.ts
@@ -143,6 +143,11 @@ export default class AfrimInput {
       },
       (err) => {
         console.error(`Error downloading configuration file: ${err}`);
+
+        // We release the textfield
+        this.textFieldElement.disabled = false;
+        this.downloadStatusElement.hidden = true;
+        this.textFieldElement.dataset.lock = "false";
       },
     );
   }


### PR DESCRIPTION
### Related issues
- #40 

### Change
In case that the `afrim-input` fail during initialization, the text field will be released to permit the user to go back to the traditional typing.