### PR TITLE
doc(afrim-input): update the code on the readme

### DIFF
--- a/packages/afrim-input/README.md
+++ b/packages/afrim-input/README.md
@@ -23,7 +23,7 @@ You can find it here [npm/afrim-input-lite](https://www.npmjs.com/package/afrim-
 In its simplest case, `afrim-input` can be initialised with a single line of Javascript:
 
 ```js
-new Afrim({
+new AfrimInput({
   textFieldElementID: "textfield",
   downloadStatusElementID: "download-status",
   tooltipElementID: "tooltip",


### PR DESCRIPTION
### Description
After the renaming of `Afrim`  by `AfrimInput`, the README had not been updated.
The change has been introduced at PR #35.

### Change
Renamed `Afrim` by `AfrimInput`.